### PR TITLE
fix: remove dependency between tests

### DIFF
--- a/.github/workflows/kibot-check.yml
+++ b/.github/workflows/kibot-check.yml
@@ -34,7 +34,6 @@ jobs:
 
   DRC:
     runs-on: ubuntu-latest
-    needs: ERC
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
allow ERC and DRC to run in parallel